### PR TITLE
profile and admin info now still obtained with refresh

### DIFF
--- a/src/components/auth/AuthProvider.js
+++ b/src/components/auth/AuthProvider.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useState, useEffect } from "react"
 
 export const ProfileContext = React.createContext()
 
@@ -9,12 +9,20 @@ export const ProfileProvider = (props) => {
     const getProfile = () => {
         return fetch("http://localhost:8000/profile", {
             headers: {
-                "Authorization": `Token ${localStorage.getItem("lu_token")}`
+                "Authorization": `Token ${localStorage.getItem("rare_user_id")}`
             }
         })
             .then(response => response.json())
             .then(setProfile)
     }
+
+    useEffect(getProfile, [])
+
+    useEffect(() => {
+        if (profile.user) {
+            setIsAdmin(profile.user.is_staff)
+        }
+    }, [profile])
 
     return (
         <ProfileContext.Provider value={{


### PR DESCRIPTION
## Description
GET function created for user profile

## Motivation and Context
Allows for obtaining current user's profile and admin status

## How Has This Been Tested?
run on client and server:
```
git fetch --all
git checkout ps-get-profile
```
admin status should stay in state even after refreshing the browser

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.