### PR TITLE
Ps admin approve posts

### DIFF
--- a/src/components/posts/PostList.js
+++ b/src/components/posts/PostList.js
@@ -1,11 +1,14 @@
 import React, { useContext, useEffect, useState } from "react"
-
 import { Link } from "react-router-dom"
+
+import { ProfileContext } from "../auth/AuthProvider"
 import { PostContext } from "./PostProvider"
 import "./Posts.css"
 
 export const PostList = props => {
     const { posts, getAllPosts, getPostsByUser, myposts } = useContext(PostContext)
+    const { isAdmin } = useContext(ProfileContext)
+
 
     const [view, setView] = useState('all')
 
@@ -23,23 +26,11 @@ export const PostList = props => {
         else {
             getAllPosts()
         }
-    }, [])
+    }, []) 
 
-    // useEffect(() => {
-    //     getAllPosts()
-    // }, [])
-
-    // useEffect(() => {
-    //     const owner = posts.find(p => p.is_owner === true) || {}
-        
-    //         if (owner != undefined) {
-    //             getPostsByUser(owner.author_id)
-                
-    //     }
-        
-    // }, [posts])
-
-    
+    const approvalHandler = (e) => {
+        console.log(e.target.id)
+    };
 
     return (
         <div>
@@ -61,25 +52,42 @@ export const PostList = props => {
                                 return false
                             }
                         }
-                        return <section className = "post-preview" key={post.id}>
-                            <div className = "post-preview-header">
-                                By: {post.author.user.first_name} {post.author.user.last_name}
-                                {ableToEdit() ? (<span className="edit-button"> {/* If user id matches the post.user_id they will be able to edit post */}
-                                    <i className="fas fa-edit"
-                                    style={{cursor:'pointer'}}
-                                    onClick={() => {props.history.push(`/posts/edit/${post.id}`)}}>Edit</i>
-                                </span>) : <span className="edit-button"> </span>}
-                                
-                            </div>
-                            <div className="post-preview-title">
-                                <Link to={`/posts/${post.id}`}>
-                                    <h3>{post.title}</h3>
-                                </Link>
-                            </div>
-                            <div className = "post-preview-footer">
-                                Category: {post.category.label}
-                            </div>
-                        </section>
+                        return (
+                            <section className = "post-preview" key={post.id}>
+                                <div className = "post-preview-header">
+                                    By: {post.author.user.first_name} {post.author.user.last_name}
+                                    {ableToEdit() ? (<span className="edit-button"> {/* If user id matches the post.user_id they will be able to edit post */}
+                                        <i className="fas fa-edit"
+                                        style={{cursor:'pointer'}}
+                                        onClick={() => {props.history.push(`/posts/edit/${post.id}`)}}>Edit</i>
+                                    </span>) : <span className="edit-button"> </span>}
+                                    
+                                </div>
+                                <div className="post-preview-title">
+                                    <Link to={`/posts/${post.id}`}>
+                                        <h3>{post.title}</h3>
+                                    </Link>
+                                </div>
+                                <div className = "post-preview-footer d-flex justify-content-between">
+                                    <div>
+                                        { isAdmin
+                                            ?   <div className="form-check">
+                                                    <input class="form-check-input" type="checkbox" checked={post.approved} id={post.id} onChange={approvalHandler}/>
+                                                    <label class="form-check-label" for="defaultCheck1">
+                                                        Default checkbox
+                                                    </label>
+                                                
+                                                </div>
+                                            : ''
+                                        }
+                                    </div>
+                                    <div>
+                                        Category: {post.category.label}
+                                    </div>
+                                </div>
+                            </section>
+                            
+                        )
                     })
                     : myposts.map(post => {
                         // this function checks to see if the current user has any posts that they wrote

--- a/src/components/posts/PostList.js
+++ b/src/components/posts/PostList.js
@@ -6,7 +6,7 @@ import { PostContext } from "./PostProvider"
 import "./Posts.css"
 
 export const PostList = props => {
-    const { posts, getAllPosts, getPostsByUser, myposts } = useContext(PostContext)
+    const { posts, getAllPosts, getPostsByUser, myposts, approvePost } = useContext(PostContext)
     const { isAdmin } = useContext(ProfileContext)
 
 
@@ -29,7 +29,10 @@ export const PostList = props => {
     }, []) 
 
     const approvalHandler = (e) => {
-        console.log(e.target.id)
+        const index = e.target.dataset.index;
+        const post = posts[index]
+        // post.approved = !posts[index].approved
+        approvePost(post.id, !post.approved)
     };
 
     return (
@@ -43,7 +46,7 @@ export const PostList = props => {
                     props.history.push("/posts/create")}>Add New Post</button>
 
                 {userPost ?
-                    posts.map(post => {
+                    posts.map((post, index) => {
                         // this function checks to see if the current user has any posts that they wrote
                         const ableToEdit = () => {
                             if (post.is_owner === true) {
@@ -52,42 +55,46 @@ export const PostList = props => {
                                 return false
                             }
                         }
-                        return (
-                            <section className = "post-preview" key={post.id}>
-                                <div className = "post-preview-header">
-                                    By: {post.author.user.first_name} {post.author.user.last_name}
-                                    {ableToEdit() ? (<span className="edit-button"> {/* If user id matches the post.user_id they will be able to edit post */}
-                                        <i className="fas fa-edit"
-                                        style={{cursor:'pointer'}}
-                                        onClick={() => {props.history.push(`/posts/edit/${post.id}`)}}>Edit</i>
-                                    </span>) : <span className="edit-button"> </span>}
-                                    
-                                </div>
-                                <div className="post-preview-title">
-                                    <Link to={`/posts/${post.id}`}>
-                                        <h3>{post.title}</h3>
-                                    </Link>
-                                </div>
-                                <div className = "post-preview-footer d-flex justify-content-between">
-                                    <div>
-                                        { isAdmin
-                                            ?   <div className="form-check">
-                                                    <input class="form-check-input" type="checkbox" checked={post.approved} id={post.id} onChange={approvalHandler}/>
-                                                    <label class="form-check-label" for="defaultCheck1">
-                                                        Default checkbox
-                                                    </label>
-                                                
-                                                </div>
-                                            : ''
-                                        }
+
+                        if (post.approved || isAdmin) {
+                            return (
+                                <section className = "post-preview" key={post.id}>
+                                    <div className = "post-preview-header">
+                                        By: {post.author.user.first_name} {post.author.user.last_name}
+                                        {ableToEdit() ? (<span className="edit-button"> {/* If user id matches the post.user_id they will be able to edit post */}
+                                            <i className="fas fa-edit"
+                                            style={{cursor:'pointer'}}
+                                            onClick={() => {props.history.push(`/posts/edit/${post.id}`)}}>Edit</i>
+                                        </span>) : <span className="edit-button"> </span>}
+                                        
                                     </div>
-                                    <div>
-                                        Category: {post.category.label}
+                                    <div className="post-preview-title">
+                                        <Link to={`/posts/${post.id}`}>
+                                            <h3>{post.title}</h3>
+                                        </Link>
                                     </div>
-                                </div>
-                            </section>
-                            
-                        )
+                                    <div className = "post-preview-footer d-flex justify-content-between">
+                                        <div>
+                                            { isAdmin
+                                                ?   <div className="form-check">
+                                                        <input class="form-check-input" type="checkbox" checked={post.approved} id={post.id} data-index={index} onChange={approvalHandler}/>
+                                                        <label class="form-check-label" for="defaultCheck1">
+                                                            Approved
+                                                        </label>
+                                                    
+                                                    </div>
+                                                : ''
+                                            }
+                                        </div>
+                                        <div>
+                                            Category: {post.category.label}
+                                        </div>
+                                    </div>
+                                </section>
+                                
+                            )
+                        }
+                        
                     })
                     : myposts.map(post => {
                         // this function checks to see if the current user has any posts that they wrote

--- a/src/components/posts/PostProvider.js
+++ b/src/components/posts/PostProvider.js
@@ -80,6 +80,18 @@ export const PostProvider = (props) => {
             .then(getAllPosts)
     }
 
+    const approvePost = (postId, isApproved) => {
+        return fetch(`http://localhost:8000/posts/${postId}`, {
+            method: "PATCH",
+            headers: {
+                "Content-Type": "application/json",
+                "Authorization": `Token ${token}`
+            },
+            body: JSON.stringify({ approved: isApproved })
+        })
+            .then(getAllPosts)
+    }
+
     const parsePostContent = (content) => content.replaceAll('</p>', '').split('<p>')
 
     return (
@@ -93,7 +105,8 @@ export const PostProvider = (props) => {
             getPostsByUser,
             deletePost,
             updatePost,
-            myposts
+            myposts,
+            approvePost
         }}>
             {props.children}
         </PostContext.Provider>

--- a/src/components/posts/Posts.css
+++ b/src/components/posts/Posts.css
@@ -27,7 +27,6 @@
 .post-preview-footer {
     width: 100%;
     font-size: 0.7rem;
-    text-align: end;
 }
 
 .post {

--- a/src/components/tags/TagCheckbox.js
+++ b/src/components/tags/TagCheckbox.js
@@ -15,7 +15,9 @@ export const TagBoxes = (props) => {
     }, [postTags])
 
     useEffect(() => {
-        getPostTagsByPost(props.post.id)
+        if (props.post.id) {
+            getPostTagsByPost(props.post.id)
+        }
     },[props.editMode, props.post.id])
 
 


### PR DESCRIPTION
## Description
Admins now can approve posts, and authors can only view posts that have been approved

## Motivation and Context
closes #87

## How Has This Been Tested?
- run on both client and server:
```
git fetch --all
git checkout ps-admin-approve-posts
```
- Login as an admin
- Home view should display checkboxes indicating if post is approved
- Toggling checkbox will toggle posts approval status
- Login as author
- Home view should only display approved posts

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.